### PR TITLE
Include throwable in FailedWorkRecycler log statement

### DIFF
--- a/core/src/main/java/com/expediagroup/rhapsody/core/work/FailedWorkRecycler.java
+++ b/core/src/main/java/com/expediagroup/rhapsody/core/work/FailedWorkRecycler.java
@@ -54,12 +54,12 @@ public abstract class FailedWorkRecycler<W extends Work, R> implements FailureCo
 
     protected void hookOnRecycle(W work, R recycled, Throwable error) {
         LOGGER.warn("Recycling failure of Work={}: subject={} recycled={} error={}",
-            work.getClass().getSimpleName(), work.workHeader().subject(), recycled, error.getMessage());
+            work.getClass().getSimpleName(), work.workHeader().subject(), recycled, error.getMessage(), error);
     }
 
     protected void hookOnDrop(W work, Throwable error) {
         LOGGER.warn("Dropping failed Work={}: subject={} error={}",
-            work.getClass().getSimpleName(), work.workHeader().subject(), error.getMessage());
+            work.getClass().getSimpleName(), work.workHeader().subject(), error.getMessage(), error);
     }
 
     protected abstract R recycle(W work, Throwable error);


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [X] Code is up-to-date with the `master` branch.
* [X] You've successfully built the project locally.
  https://github.com/ExpediaGroup/rhapsody#building
* [X] There are new or updated unit tests validating the change.

Refer to CONTRIBUTING.md for more details.
  https://github.com/ExpediaGroup/rhapsody/blob/master/CONTRIBUTING.md
-->

### :pencil: Description
Minor enhancement for easier troubleshoot of failures - passing the throwable as the last parameter into slf4j logger allows the stack trace and root cause exception to show up in the logs.  

Was tested by running locally and verifying the log entries contain more information than just the exception message
### :link: Related Issues
