### PR TITLE
[#37]Upgrade to later stable versions of multiple libraries

### DIFF
--- a/api/src/test/java/com/expediagroup/rhapsody/api/AcknowledgeableTest.java
+++ b/api/src/test/java/com/expediagroup/rhapsody/api/AcknowledgeableTest.java
@@ -382,7 +382,9 @@ public class AcknowledgeableTest {
             .expectComplete()
             .verify();
 
-        Flux.from(publisher).subscribe();
+        Flux.from(publisher).subscribe(
+            data -> {},
+            error -> { throw error instanceof  RuntimeException ? RuntimeException.class.cast(error) : new RuntimeException(error); });
     }
 
     private Collection<String> extractCharacters(String string) {

--- a/dropwizard/pom.xml
+++ b/dropwizard/pom.xml
@@ -16,22 +16,22 @@
             <dependency>
                 <groupId>io.dropwizard</groupId>
                 <artifactId>dropwizard-core</artifactId>
-                <version>1.1.8</version>
+                <version>2.0.8</version>
             </dependency>
             <dependency>
                 <groupId>io.dropwizard</groupId>
                 <artifactId>dropwizard-lifecycle</artifactId>
-                <version>1.1.8</version>
+                <version>2.0.8</version>
             </dependency>
             <dependency>
                 <groupId>io.dropwizard.metrics</groupId>
                 <artifactId>metrics-core</artifactId>
-                <version>3.2.2</version>
+                <version>4.1.9</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-util</artifactId>
-                <version>9.4.11.v20180605</version>
+                <version>9.4.28.v20200408</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/kafka-test/pom.xml
+++ b/kafka-test/pom.xml
@@ -36,7 +36,8 @@
         </dependency>
         <dependency>
             <groupId>org.apache.kafka</groupId>
-            <artifactId>kafka_2.11</artifactId>
+            <artifactId>kafka_2.12</artifactId>
+            <!--NOTE: Version should change to ${confluent.version}-ccs on upgrade to confluent >= 5.3.0-->
             <version>${apache-kafka.version}</version>
             <exclusions>
                 <exclusion>

--- a/pom.xml
+++ b/pom.xml
@@ -77,13 +77,13 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <!--Library Versions-->
-        <apache-kafka.version>2.0.0</apache-kafka.version>
-        <confluent.version>4.1.3</confluent.version>
-        <jackson.version>2.9.8</jackson.version>
+        <apache-kafka.version>2.3.1</apache-kafka.version>
+        <confluent.version>5.2.4</confluent.version>
+        <jackson.version>2.10.3</jackson.version>
         <jakarta-xml.version>2.3.3</jakarta-xml.version>
         <opentracing.version>0.32.0</opentracing.version>
-        <reactor.version>3.3.1.RELEASE</reactor.version>
-        <slf4j.version>1.7.26</slf4j.version>
+        <reactor.version>3.3.5.RELEASE</reactor.version>
+        <slf4j.version>1.7.30</slf4j.version>
     </properties>
 
     <dependencyManagement>
@@ -158,7 +158,7 @@
             <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
-                <version>27.0-jre</version>
+                <version>28.2-jre</version>
             </dependency>
             <dependency>
                 <groupId>com.rabbitmq</groupId>
@@ -278,6 +278,16 @@
 
             <!--Third Party Transitive Dependencies (Satisfy Upper Bounds)-->
             <dependency>
+                <groupId>com.101tec</groupId>
+                <artifactId>zkclient</artifactId>
+                <version>0.11</version>
+            </dependency>
+            <dependency>
+                <groupId>com.thoughtworks.paranamer</groupId>
+                <artifactId>paranamer</artifactId>
+                <version>2.8</version>
+            </dependency>
+            <dependency>
                 <groupId>jakarta.activation</groupId>
                 <artifactId>jakarta.activation-api</artifactId>
                 <version>1.2.2</version>
@@ -285,7 +295,12 @@
             <dependency>
                 <groupId>org.apache.zookeeper</groupId>
                 <artifactId>zookeeper</artifactId>
-                <version>3.4.14</version>
+                <version>3.5.7</version>
+            </dependency>
+            <dependency>
+                <groupId>org.checkerframework</groupId>
+                <artifactId>checker-qual</artifactId>
+                <version>3.4.0</version>
             </dependency>
             <dependency>
                 <groupId>org.javassist</groupId>
@@ -293,9 +308,14 @@
                 <version>3.27.0-GA</version>
             </dependency>
             <dependency>
+                <groupId>org.scala-lang</groupId>
+                <artifactId>scala-library</artifactId>
+                <version>2.12.10</version>
+            </dependency>
+            <dependency>
                 <groupId>org.xerial.snappy</groupId>
                 <artifactId>snappy-java</artifactId>
-                <version>1.1.7.2</version>
+                <version>1.1.7.3</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/samples/dropwizard/pom.xml
+++ b/samples/dropwizard/pom.xml
@@ -48,8 +48,12 @@
             <artifactId>reactor-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.validation</groupId>
-            <artifactId>validation-api</artifactId>
+            <groupId>jakarta.validation</groupId>
+            <artifactId>jakarta.validation-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.reactivestreams</groupId>
@@ -70,12 +74,12 @@
             <artifactId>kafka-clients</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.glassfish.hk2</groupId>
-            <artifactId>hk2-api</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.glassfish.jersey.containers</groupId>
             <artifactId>jersey-container-servlet-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.core</groupId>
+            <artifactId>jersey-common</artifactId>
         </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.core</groupId>

--- a/samples/dropwizard/src/main/java/com/exepdiagroup/rhapsody/samples/dropwizard/kafka/SampleKafkaApplication.java
+++ b/samples/dropwizard/src/main/java/com/exepdiagroup/rhapsody/samples/dropwizard/kafka/SampleKafkaApplication.java
@@ -17,8 +17,9 @@ package com.exepdiagroup.rhapsody.samples.dropwizard.kafka;
 
 import java.util.function.Consumer;
 
-import org.glassfish.hk2.api.TypeLiteral;
-import org.glassfish.hk2.utilities.binding.AbstractBinder;
+import javax.ws.rs.core.GenericType;
+
+import org.glassfish.jersey.internal.inject.AbstractBinder;
 
 import com.expediagroup.rhapsody.dropwizard.metrics.DefaultDropwizardMeterRegistry;
 import com.expediagroup.rhapsody.kafka.test.TestKafkaFactory;
@@ -57,7 +58,7 @@ public class SampleKafkaApplication extends Application<SampleKafkaApplicationCo
             @Override
             protected void configure() {
                 // Bind a Consumer that we'll access in Bundle(s)
-                this.<Consumer<String>>bind(System.out::println).to(new TypeLiteral<Consumer<String>>() {});
+                this.<Consumer<String>>bind(System.out::println).to(new GenericType<Consumer<String>>() {});
             }
         });
     }

--- a/samples/dropwizard/src/main/java/com/exepdiagroup/rhapsody/samples/dropwizard/kafka/SampleKafkaProcessingStanzaBundle.java
+++ b/samples/dropwizard/src/main/java/com/exepdiagroup/rhapsody/samples/dropwizard/kafka/SampleKafkaProcessingStanzaBundle.java
@@ -18,7 +18,8 @@ package com.exepdiagroup.rhapsody.samples.dropwizard.kafka;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
-import org.glassfish.hk2.api.TypeLiteral;
+import javax.ws.rs.core.GenericType;
+
 import org.glassfish.jersey.servlet.ServletContainer;
 
 import com.expediagroup.rhapsody.core.stanza.Stanza;
@@ -46,8 +47,8 @@ public class SampleKafkaProcessingStanzaBundle<T> extends StanzaBundle<T, Sample
         // For the sake of showing possibilities, we'll look for a Consumer resource in the environment
         Consumer<String> consumer = ServletContainer.class.cast(environment.getJerseyServletContainer())
             .getApplicationHandler()
-            .getServiceLocator()
-            .getService(new TypeLiteral<Consumer<String>>() {}.getType());
+            .getInjectionManager()
+            .getInstance(new GenericType<Consumer<String>>() {}.getType());
 
         return new SampleKafkaProcessingStanzaConfig(config.getBootstrapServers(), config.getTopic(), consumer);
     }

--- a/samples/pom.xml
+++ b/samples/pom.xml
@@ -17,7 +17,7 @@
     </modules>
 
     <properties>
-        <dropwizard.version>1.1.8</dropwizard.version>
+        <dropwizard.version>2.0.8</dropwizard.version>
     </properties>
 
     <dependencyManagement>
@@ -26,14 +26,14 @@
             <dependency>
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-bom</artifactId>
-                <version>9.4.14.v20181114</version>
+                <version>9.4.28.v20200408</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.glassfish.jersey</groupId>
                 <artifactId>jersey-bom</artifactId>
-                <version>2.25.1</version>
+                <version>2.31</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -50,14 +50,14 @@
                 <version>${dropwizard.version}</version>
             </dependency>
             <dependency>
-                <groupId>javax.validation</groupId>
-                <artifactId>validation-api</artifactId>
-                <version>2.0.1.Final</version>
+                <groupId>jakarta.validation</groupId>
+                <artifactId>jakarta.validation-api</artifactId>
+                <version>2.0.2</version>
             </dependency>
             <dependency>
-                <groupId>org.glassfish.hk2</groupId>
-                <artifactId>hk2-api</artifactId>
-                <version>2.6.1</version>
+                <groupId>jakarta.ws.rs</groupId>
+                <artifactId>jakarta.ws.rs-api</artifactId>
+                <version>2.1.6</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
### :pencil: Description
- Dropwizard 1.x -> 2.0.8
- Jackson 2.9.8 -> 2.10.3
- Reactor 3.3.1.RELEASE -> 3.3.5.RELEASE
- Update PartitionAssignor test to be easier to refactor for kafka-clients >=2.4.0
- Use updated Dropwizard conventions (avoid direct HK2 dependencies)

### :link: Related Issues

#37 