### PR TITLE
[#36]Build with Java11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 os: linux
 language: java
 jdk:
-  - openjdk8
+  - openjdk11
 cache:
   directories:
     - "~/.m2/repository"

--- a/pom.xml
+++ b/pom.xml
@@ -80,6 +80,7 @@
         <apache-kafka.version>2.0.0</apache-kafka.version>
         <confluent.version>4.1.3</confluent.version>
         <jackson.version>2.9.8</jackson.version>
+        <jakarta-xml.version>2.3.3</jakarta-xml.version>
         <opentracing.version>0.31.0</opentracing.version>
         <reactor.version>3.3.1.RELEASE</reactor.version>
         <slf4j.version>1.7.26</slf4j.version>
@@ -235,6 +236,11 @@
                 <version>1.4.0.RELEASE</version>
             </dependency>
             <dependency>
+                <groupId>jakarta.xml.bind</groupId>
+                <artifactId>jakarta.xml.bind-api</artifactId>
+                <version>${jakarta-xml.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>junit</groupId>
                 <artifactId>junit</artifactId>
                 <version>4.12</version>
@@ -248,6 +254,11 @@
                 <groupId>org.apache.kafka</groupId>
                 <artifactId>kafka-clients</artifactId>
                 <version>${apache-kafka.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.glassfish.jaxb</groupId>
+                <artifactId>jaxb-runtime</artifactId>
+                <version>${jakarta-xml.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.reactivestreams</groupId>
@@ -267,6 +278,11 @@
 
             <!--Third Party Transitive Dependencies (Satisfy Upper Bounds)-->
             <dependency>
+                <groupId>jakarta.activation</groupId>
+                <artifactId>jakarta.activation-api</artifactId>
+                <version>1.2.2</version>
+            </dependency>
+            <dependency>
                 <groupId>org.apache.zookeeper</groupId>
                 <artifactId>zookeeper</artifactId>
                 <version>3.4.14</version>
@@ -274,7 +290,7 @@
             <dependency>
                 <groupId>org.javassist</groupId>
                 <artifactId>javassist</artifactId>
-                <version>3.22.0-GA</version>
+                <version>3.27.0-GA</version>
             </dependency>
             <dependency>
                 <groupId>org.xerial.snappy</groupId>

--- a/rabbitmq/pom.xml
+++ b/rabbitmq/pom.xml
@@ -36,11 +36,20 @@
             <artifactId>opentracing-api</artifactId>
         </dependency>
         <dependency>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>
 
         <!--Third Party Test Dependencies-->
+        <dependency>
+            <groupId>org.glassfish.jaxb</groupId>
+            <artifactId>jaxb-runtime</artifactId>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>


### PR DESCRIPTION
### :pencil: Description

Enable building with Java11 by bringing in explicit Jakarta XML dependencies that were removed from JDK

### :link: Related Issues

#36 