### PR TITLE
[#61]Downgrade OpenTracing to 0.32.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
         <confluent.version>4.1.3</confluent.version>
         <jackson.version>2.9.8</jackson.version>
         <jakarta-xml.version>2.3.3</jakarta-xml.version>
-        <opentracing.version>0.33.0</opentracing.version>
+        <opentracing.version>0.32.0</opentracing.version>
         <reactor.version>3.3.1.RELEASE</reactor.version>
         <slf4j.version>1.7.26</slf4j.version>
     </properties>


### PR DESCRIPTION
Since OpenTracing 0.33.0 contains breaking changes and we're not doing major bumps, let's downgrade to 0.32.0, which contains both the new and old OpenTracing methods. This will allow clients to not have to adopt breaking changes in their code, but allow them to use Rhapsody OpenTracing features once they upgrade to 0.32.0 or later